### PR TITLE
migrate travis to container-based infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: php
 php:
   - 5.4
@@ -6,9 +7,8 @@ php:
 services:
   - elasticsearch
 install:
-  - "echo 'script.disable_dynamic: false' | sudo tee -a /etc/elasticsearch/elasticsearch.yml"
-  - sudo service elasticsearch restart
-  - sudo pip install -q sphinx --use-mirrors
+  - pip install --upgrade pip --user `whoami`
+  - pip install -q sphinx --use-mirrors  --user `whoami`
   - wget -q -O conf.py https://raw.githubusercontent.com/ongr-io/docs-aggregator/master/source/conf-travis.py
   - mkdir _static
 before_script:

--- a/Tests/app/fixture/Acme/TestBundle/Document/Product.php
+++ b/Tests/app/fixture/Acme/TestBundle/Document/Product.php
@@ -24,7 +24,7 @@ class Product extends AbstractDocument
     /**
      * @var string
      *
-     * @ES\Property(name="title", type="string", search_analyzer="standard")
+     * @ES\Property(name="title", type="string", searchAnalyzer="standard")
      */
     public $title;
 


### PR DESCRIPTION
Dynamic scripting is already enabled in Travis newer versions:
https://github.com/travis-ci/travis-cookbooks/commit/72362642788e757f52a7985b945b405285455923
